### PR TITLE
Fix metrics labels and add login test

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@react-spring/web": "^9.7.5",
@@ -33,6 +34,10 @@
     "eslint-plugin-react-refresh": "0.4.6",
     "globals": "13.24.0",
     "postcss": "^8.4.38",
-    "tailwindcss": "^3.4.17"
+    "tailwindcss": "^3.4.17",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.1.4",
+    "@testing-library/user-event": "^14.4.3",
+    "vitest": "^1.2.0"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -92,7 +92,3 @@ export default function App() {
     </ThemeProvider>
   );
 }
-
-// Added industry selection option to the profile.
-// This will allow users to specify their industry during profile setup or editing.
-// ...existing code...

--- a/src/__tests__/LoginPage.test.jsx
+++ b/src/__tests__/LoginPage.test.jsx
@@ -1,0 +1,51 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+import axios from 'axios';
+import LoginPage from '../pages/LoginPage';
+
+vi.mock('axios');
+
+const navigateMock = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+describe('LoginPage', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    localStorage.clear();
+    axios.post.mockResolvedValue({ data: { profileId: '123' } });
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  test('successful login shows toast and navigates', async () => {
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText(/Email Address/i), {
+      target: { value: 'user@example.com' }
+    });
+    fireEvent.change(screen.getByLabelText(/Password/i), {
+      target: { value: 'password' }
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /login/i }));
+
+    await waitFor(() => expect(axios.post).toHaveBeenCalled());
+    expect(localStorage.getItem('profileId')).toBe('123');
+    expect(screen.getByText(/Logged in successfully!/i)).toBeInTheDocument();
+
+    vi.runAllTimers();
+    expect(navigateMock).toHaveBeenCalledWith('/dashboard');
+  });
+});

--- a/src/pages/AdminProfilePage.jsx
+++ b/src/pages/AdminProfilePage.jsx
@@ -118,7 +118,7 @@ export default function AdminProfilePage() {
         <div className="px-6 pb-6 space-y-3">
           <div className="flex items-center bg-gray-800 rounded-xl px-4 py-3 mb-1">
             <span className="bg-gray-700 rounded-full p-2 mr-3"><FaExchangeAlt className="text-blue-300" /></span>
-            <span className="flex-1 text-white font-medium">Contact Exchanged</span>
+            <span className="flex-1 text-white font-medium">Contact Exchanges</span>
             <span className="text-lg font-bold text-white">{insights?.contactExchanges ?? 0}</span>
           </div>
           <div className="flex items-center bg-gray-800 rounded-xl px-4 py-3 mb-1">

--- a/src/pages/DashboardInsightsPage.jsx
+++ b/src/pages/DashboardInsightsPage.jsx
@@ -117,7 +117,7 @@ export default function DashboardInsightsPage() {
           <div className="flex flex-col items-center bg-gray-800 rounded-xl px-4 py-5">
             <FaExchangeAlt className="text-yellow-300 text-xl mb-1" />
             <span className="text-lg font-bold text-white">{insights?.contactExchanges ?? 0}</span>
-            <span className="text-xs text-gray-400 mt-1">Contact Exchanged</span>
+            <span className="text-xs text-gray-400 mt-1">Contact Exchanges</span>
           </div>
           <div className="flex flex-col items-center bg-gray-800 rounded-xl px-4 py-5">
             <FaDownload className="text-purple-300 text-xl mb-1" />

--- a/src/pages/PublicProfilePage.jsx
+++ b/src/pages/PublicProfilePage.jsx
@@ -249,7 +249,7 @@ export default function PublicProfilePage() {
   // Determine top link from insights
   const topLink = insights?.topLink;
   const mostPopularContactMethod = insights?.mostPopularContactMethod;
-  const totalLinkTaps = insights?.totalTaps;
+  const totalLinkTaps = insights?.totalLinkTaps;
 
   // Card content JSX
   const CardContent = () => (

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,4 +15,8 @@ export default defineConfig({
       '@': '/src',
     },
   },
+  test: {
+    environment: 'jsdom',
+    setupFiles: './vitest.setup.js',
+  },
 });

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- fix metric label pluralization
- display totalLinkTaps on public profile
- remove outdated comment in App.jsx
- add vitest setup and a LoginPage test

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: TypeError: context.getSource is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68543e1367a883248d064ff2ec527844